### PR TITLE
Fix module import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "nodemon index.js",
     "build": ""
   },
-  "type": "commonjs",
+  "type": "module",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary
- fix Node ESM import error by setting module type

## Testing
- `node index.js`
- `npm start`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684940af476883238de28b0c480e1f79